### PR TITLE
Fix mia home directory runtime permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@
 # Use the official OpenClaw runtime image and layer workload defaults.
 FROM ghcr.io/openclaw/openclaw:latest
 
+ENV HOME=/home/node
+
+WORKDIR /home/node
+
 USER root
 RUN mkdir -p /home/node/.openclaw \
     && chown -R node:node /home/node/.openclaw


### PR DESCRIPTION
## Summary
- set HOME=/home/node in Dockerfile
- set WORKDIR /home/node to prevent writes under /nonexistent

## Why
Runtime logs show gateway startup failure:
EACCES: permission denied, mkdir '/nonexistent'

## Expected Outcome
- OpenClaw starts without home-directory permission errors
- readiness/liveness checks can evaluate the running process
