### PR TITLE
Reposition Mia as a platform and career assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
-# Mia — OpenClaw AI Gateway
+# Mia — Platform and Career Assistant
 
 **Repository Category:** `tenant` (see [REPO_TAXONOMY](https://github.com/zavestudios/platform-docs/blob/main/_platform/REPO_TAXONOMY.md))
 
-Containerized deployment of [OpenClaw](https://docs.openclaw.ai/) - a self-hosted gateway connecting chat apps (WhatsApp, Telegram, Discord, iMessage) to AI coding agents.
+Containerized deployment of [OpenClaw](https://docs.openclaw.ai/) used as a self-hosted platform and career assistant. Mia connects chat surfaces to an assistant workflow focused on planning, reminders, tracking, and platform-aware execution support.
+
+## What Mia Is
+
+Mia is a governed `tenant` workload that uses OpenClaw as the runtime surface.
+
+Current intended use:
+- maintain a career and learning roadmap
+- track weekly priorities, completed work, and blockers
+- help connect real repository work to broader platform goals
+- provide reminder and review prompts through OpenClaw heartbeat
+- draft summaries and next actions without becoming a new source of governance truth
+- prepare for a future retrospective learning loop that turns sessions into refinement proposals
+
+Mia is not yet a general autonomous agent platform. Current v1 behavior remains intentionally bounded and human-guided.
 
 ## What is OpenClaw?
 
@@ -30,7 +44,10 @@ Canonical platform documentation:
 Details to be added as the application is developed.
 
 Current assistant feature design:
-- [Mia Platform Assistant v1](docs/platform-assistant-v1.md)
+- [Mia Platform and Career Assistant v1](docs/platform-assistant-v1.md)
+- [Learning Roadmap v1](docs/learning-roadmap-v1.md)
+- [Learning Progress Tracker](docs/learning-progress-tracker.md)
+- [Weekly Review Template](docs/weekly-review-template.md)
 
 ## Local Development
 
@@ -113,6 +130,26 @@ Use the day-1 operator runbook at [docs/first-interaction.md](docs/first-interac
 Use the repeatable post-deploy check at [docs/interaction-smoke-test.md](docs/interaction-smoke-test.md).
 Use [docs/token-optimization-notes.md](docs/token-optimization-notes.md) for practical cost-control guidance.
 For a one-command operator check, run `./scripts/smoke-sandbox.sh`.
+
+## Career and Learning Workflow
+
+The current productive path for Mia is conversational and heartbeat-assisted, not fully autonomous.
+
+Use these artifacts as the working system of record:
+- roadmap: [docs/learning-roadmap-v1.md](docs/learning-roadmap-v1.md)
+- progress tracker: [docs/learning-progress-tracker.md](docs/learning-progress-tracker.md)
+- weekly review: [docs/weekly-review-template.md](docs/weekly-review-template.md)
+
+Recommended operating loop:
+1. Update the roadmap when priorities or learning goals change.
+2. Log completed work, blockers, and next actions in the tracker.
+3. Use Mia for weekly review, course correction, and reminder prompts.
+4. Use repository and issue activity as supporting evidence, not as the only progress signal.
+
+Planned next layer:
+- a retrospective learning loop aligned with `platform-docs#71`
+- session-derived proposals for memory updates, issues, and follow-up work
+- explicit queueing for higher-risk changes instead of unattended mutation
 
 ### Current Status
 

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -28,7 +28,7 @@
         "model": "ollama/llama3.2:3b",
         "session": "main",
         "target": "none",
-        "prompt": "Check: any blockers, opportunities, or progress updates needed?"
+        "prompt": "Review the active roadmap and progress tracker. Ask for any completed items, slipped commitments, blockers, or priority changes. Keep the check-in short and action-oriented."
       }
     }
   },

--- a/docs/learning-progress-tracker.md
+++ b/docs/learning-progress-tracker.md
@@ -1,0 +1,62 @@
+# Learning Progress Tracker
+
+## Purpose
+
+This file records current priorities, completed work, blockers, and next
+actions. It is the canonical evidence surface for Mia's weekly review flow.
+
+Update style:
+- keep entries short
+- prefer dated notes
+- record explicit blockers and decisions
+- avoid using repository activity as the only proof of progress
+
+## Current Week
+
+**Week of:** 2026-04-28
+
+### Top Priorities
+
+1. Reposition Mia into a useful platform and career assistant.
+2. Clarify how OpenShift learning fits the new team reality.
+3. Separate RabbitMQ capability evaluation from OpenShift-specific learning.
+
+### In Progress
+
+- Mia assistant scope is being refocused around roadmap, tracking, and weekly review.
+- RabbitMQ/OpenShift work is being reframed so capability decisions are not overfit to OpenShift.
+- Mia is being aligned with the proposed retrospective learning-loop direction from `platform-docs#71`.
+
+### Completed
+
+- 2026-04-29: documented RabbitMQ OpenShift findings in `gitops` and linked the POC artifact.
+- 2026-04-30: removed hardcoded RabbitMQ credentials from local OpenShift validation scripts.
+
+### Blockers
+
+- Mia does not yet have dedicated GitHub/GitLab identity or scoped runtime credentials for action-taking.
+- Current Mia implementation surface is config-and-docs driven, not a custom backend with durable automation state.
+
+### Next Actions
+
+- define Mia v1 as a platform and career assistant with bounded behavior
+- use the roadmap and tracker as canonical planning artifacts
+- decide which review cadence should be standard: daily prompt, weekly review, or both
+- incorporate `platform-docs#71` into Mia's future-phase design without over-claiming current autonomy
+- define proposal tiers, evidence requirements, and owning-surface rules for future learning-loop outputs
+
+## Decision Log
+
+- 2026-04-30: OpenShift remains worth learning for breadth, but no longer drives RabbitMQ platform evaluation by default.
+- 2026-04-30: V1 should prioritize useful planning and tracking over autonomous repo polling.
+- 2026-05-05: the Command Center learning-loop item should shape Mia's Phase 2 direction, but not collapse V1 into unattended automation.
+- 2026-05-05: future learning-loop outputs need explicit proposal tiers and owning-surface rules before implementation.
+
+## Evidence Links
+
+- `docs/platform-assistant-v1.md`
+- `docs/learning-roadmap-v1.md`
+- `docs/weekly-review-template.md`
+- `zavestudios/gitops#139`
+- `zavestudios/mia#21`
+- `zavestudios/platform-docs#71`

--- a/docs/learning-roadmap-v1.md
+++ b/docs/learning-roadmap-v1.md
@@ -1,0 +1,123 @@
+# Learning Roadmap v1
+
+## Purpose
+
+This document is the canonical planning surface for Mia's career and learning assistance.
+
+It defines what is being learned, why it matters, and what "good progress"
+means. Mia may read and summarize this file, but should not treat repository
+activity alone as proof that a roadmap item is complete.
+
+## Operating Rules
+
+- Keep active focus narrow.
+- Prefer outcomes over topic hoarding.
+- Tie learning goals to real work where possible.
+- Mark items complete only after explicit human confirmation.
+- Use the progress tracker for ongoing evidence and blockers.
+
+## Current Planning Horizon
+
+**Planning date:** 2026-04-30
+
+## North Star Outcomes
+
+1. Build a durable operating system for platform work, career growth, and weekly execution.
+2. Convert active ZaveStudios work into a visible portfolio of platform judgment and delivery.
+3. Maintain enough OpenShift fluency for market relevance without overfitting current learning to a team that does not use OpenShift.
+
+## Active Themes
+
+### 1. Platform and Career Operating System
+
+Why it matters:
+- This creates the management surface for priorities, reminders, follow-through, and career signaling.
+
+Desired outcome:
+- Mia becomes the default assistant for weekly planning, progress review, and execution support.
+
+Exit signals:
+- roadmap, tracker, and review loop are being used consistently
+- priorities and drift are visible week to week
+- follow-up work is captured instead of held in memory
+- Mia has a clear path from interactive review into retrospective refinement proposals
+
+### 2. Platform Delivery and Governance Fluency
+
+Why it matters:
+- This is the core ZaveStudios competency surface and the strongest source of portable platform judgment.
+
+Desired outcome:
+- architecture, GitOps, governance, and diagnostic work can be explained and executed clearly
+
+Example evidence:
+- issues, PRs, and docs linked to platform execution decisions
+- conformance and GitOps reasoning captured in written artifacts
+
+### 3. Targeted OpenShift Breadth
+
+Why it matters:
+- OpenShift remains market-relevant even if it is not central to the new team.
+
+Desired outcome:
+- retain practical fluency in SCCs, Routes, operators, and day-1 cluster troubleshooting
+
+Constraints:
+- do not let OpenShift dominate the roadmap if it is no longer the main execution environment
+- use it as breadth, not as the sole proving ground for platform capability choices
+
+### 4. Capability Evaluation Discipline
+
+Why it matters:
+- platform candidates like RabbitMQ should be evaluated for platform fit, not just for novelty
+
+Desired outcome:
+- separate learning exercises from platform promotion decisions
+- evaluate capabilities against tenant need, governance fit, and operating burden
+
+### 5. Retrospective Learning Loop
+
+Why it matters:
+- repeated fixes and missed checks should become durable improvements instead of remaining session-local knowledge
+
+Desired outcome:
+- session work can produce structured follow-up proposals for memory, issues, docs, and review queues
+
+Constraints:
+- do not skip review for GitOps, CI, policy, or governance changes
+- do not confuse transcript-derived patterns with confirmed roadmap completion
+- keep owning-surface boundaries explicit so learning outputs land in the right repo
+
+## Near-Term Focus
+
+### Next 30 Days
+
+- stabilize Mia as a useful planning and review assistant
+- convert current learning goals into a smaller weekly execution loop
+- keep OpenShift learning active but bounded
+- translate one or two active platform decisions into durable written artifacts
+- align Mia's future shape with the proposed `LEARNING_LOOP_MODEL` in `platform-docs#71`
+
+### Keep Warm, Not Primary
+
+- RabbitMQ as an OpenShift-first exercise
+- broad automation ambitions before Mia identity and approval controls exist
+- any learning topic that does not currently map to role relevance, platform leverage, or visible portfolio value
+
+## Decision Rules For Prioritization
+
+When multiple options compete, prefer work that:
+
+1. sharpens platform judgment
+2. creates durable written artifacts or shipped improvements
+3. supports current role effectiveness
+4. improves future marketability
+5. reduces personal coordination overhead
+
+## Open Questions
+
+- Which career signals should Mia track explicitly each week?
+- Which repos and issue surfaces should count as supporting evidence?
+- When should Mia progress from reminder/review behavior into scoped write actions under her own identity?
+- What proposal types are safe enough for a future learning loop to draft automatically?
+- What is the minimum evidence threshold before a repeated pattern becomes a durable proposal?

--- a/docs/platform-assistant-v1.md
+++ b/docs/platform-assistant-v1.md
@@ -1,11 +1,14 @@
-# Mia Platform Assistant v1
+# Mia Platform and Career Assistant v1
 
 ## Purpose
 
-Mia v1 extends the existing OpenClaw-based tenant into a doctrine-aware platform assistant for ZaveStudios.
+Mia v1 extends the existing OpenClaw-based tenant into a doctrine-aware platform and career assistant for Xavier Lopez and ZaveStudios.
 
 Mia may:
 
+- maintain roadmap-oriented working memory through canonical planning artifacts
+- support learning reviews, career planning, and weekly prioritization
+- prepare structured findings for a future retrospective learning loop
 - read GitHub and GitLab issues and discussions
 - classify friction and platform work items
 - compute measurement snapshots from governed repositories
@@ -23,7 +26,7 @@ Canonical authority remains in `platform-docs/_platform/`.
 
 ## Why This Exists
 
-This capability operationalizes documented platform workflows without moving authority out of `platform-docs`.
+This capability operationalizes documented platform workflows without moving authority out of `platform-docs`, while also turning active platform work into a usable career and learning operating system.
 
 Primary doctrine inputs:
 
@@ -34,10 +37,17 @@ Primary doctrine inputs:
 - `FRICTION_FEEDBACK.md`
 - `AUDIT_PROGRAM.md`
 
+Adjacent future-model input:
+
+- `platform-docs#71` (`LEARNING_LOOP_MODEL.md`, proposed)
+
 ## Scope
 
 ### Included in v1
 
+- manual-trigger roadmap review and weekly planning
+- conversational progress tracking against canonical local artifacts
+- heartbeat-driven reminder and check-in prompts
 - manual-trigger issue and discussion triage
 - friction triage aligned to `FRICTION_FEEDBACK.md`
 - measurement snapshots for metrics derivable from repository and issue-system state
@@ -47,6 +57,8 @@ Primary doctrine inputs:
 
 ### Explicitly Excluded in v1
 
+- autonomous interpretation of repo activity as completed learning progress
+- autonomous transcript ingestion and overnight proposal execution
 - autonomous polling and scheduled write actions
 - automatic issue closure or reassignment
 - GitOps mutation
@@ -56,10 +68,11 @@ Primary doctrine inputs:
 
 ## Repository Scope
 
-This initiative is primarily single-repo in `mia`.
+This implementation slice is primarily single-repo in `mia`.
 
 Read sources include:
 
+- local planning and tracking artifacts under `mia/docs/`
 - `platform-docs/_platform/`
 - `gitops/`
 - governed repositories defined by `platform-docs/_platform/REPO_TAXONOMY.md`
@@ -87,6 +100,10 @@ Mia remains a governed `tenant` workload.
 
 Mia must consume doctrine. It must not become doctrine.
 
+For career and learning use, Mia must also consume planning artifacts. It must not silently rewrite goals or mark progress complete without explicit user interaction or approval.
+
+If Mia later participates in a retrospective learning loop, that loop must still respect the same control boundary: low-risk findings may be drafted automatically, but GitOps, policy, and other higher-risk changes must remain queued for human review.
+
 ## Capability Modules
 
 ### 1. `policy_reader`
@@ -100,6 +117,19 @@ Responsibilities:
 
 - scope resolution from `REPO_TAXONOMY.md`
 - doctrine lookup for friction, measurement, audit, and control-plane questions
+
+### 1a. `roadmap_reader`
+
+Purpose:
+
+- load the canonical roadmap, tracker, and weekly review artifacts
+- answer questions about current priorities, stale goals, and blocked work
+
+Responsibilities:
+
+- identify active priorities and current phase
+- compare stated goals with recorded progress
+- surface stale or conflicting commitments
 
 ### 2. `issue_triage`
 
@@ -172,13 +202,46 @@ Responsibilities:
 - formation progress reports
 - audit summaries
 - proposed issue and discussion comments
+- weekly reviews and progress summaries
+
+### 7. `career_coach`
+
+Purpose:
+
+- translate platform work and learning goals into practical weekly execution
+
+Responsibilities:
+
+- recommend next actions
+- identify overcommitment or drift
+- suggest when a learning topic should move from exploration to execution
+- connect repository work back to broader career goals
+
+### 8. `learning_loop_adapter`
+
+Purpose:
+
+- define the interface between Mia's interactive workflows and a future retrospective refinement loop
+
+Responsibilities:
+
+- normalize candidate findings from sessions into reviewable proposals
+- separate low-risk outputs from high-risk changes
+- preserve evidence links back to roadmap, tracker, and source sessions
+- avoid direct execution of queued infrastructure or policy mutations in v1
 
 ## Trigger Surface
 
-V1 is manual-trigger only.
+V1 is manual-trigger plus heartbeat-prompt only.
 
 Supported command shapes:
 
+- `review roadmap`
+- `review week`
+- `show current priorities`
+- `mark progress <item>`
+- `log blocker <item>`
+- `draft learning-loop finding`
 - `triage issue github <owner>/<repo>#<number>`
 - `triage issue gitlab <project>#<number>`
 - `triage discussion <url>`
@@ -195,6 +258,7 @@ Not supported in v1:
 - background polling
 - webhook-driven autonomous actions
 - recurring unattended writes
+- autonomous tracker updates based only on repo events
 
 ## Output Contract
 
@@ -258,6 +322,59 @@ Report-oriented tasks may additionally produce Markdown artifacts.
 }
 ```
 
+### `RoadmapReviewResult`
+
+```json
+{
+  "type": "RoadmapReviewResult",
+  "captured_at": "2026-04-30T00:00:00Z",
+  "current_priorities": [],
+  "completed_since_last_review": [],
+  "slipped_items": [],
+  "blockers": [],
+  "recommended_next_actions": [],
+  "sources": [],
+  "requires_human_approval": true
+}
+```
+
+### `LearningLoopFinding`
+
+```json
+{
+  "type": "LearningLoopFinding",
+  "captured_at": "2026-05-05T00:00:00Z",
+  "source_kind": "session|issue|repo-work|manual-note",
+  "pattern": "repeated-fix|missing-ci-check|manual-step-without-automation|control-plane-clarity-gap",
+  "summary": "",
+  "evidence": [],
+  "target_surface": "mia-doc|mia-memory|repo-issue|platform-docs-issue|review-queue",
+  "proposed_output": "memory-update|issue-draft|doc-update-draft|review-queue",
+  "risk_level": "low|medium|high",
+  "requires_human_approval": true
+}
+```
+
+### Evidence Requirements For `LearningLoopFinding`
+
+Every finding should include enough evidence to survive review without relying
+on memory or chat archaeology.
+
+Minimum evidence set:
+
+- source reference
+- concise problem statement
+- repeated pattern or missed-check explanation
+- proposed target surface
+- why the proposal would reduce future troubleshooting time or improve predictability
+
+Preferred evidence set:
+
+- repeated occurrence count or multiple examples
+- affected repos or control planes
+- existing workaround or manual-step reference
+- candidate durable fix category
+
 ### `AuditEvidenceBundle`
 
 ```json
@@ -291,11 +408,12 @@ Report-oriented tasks may additionally produce Markdown artifacts.
 Assistant execution should follow this order:
 
 1. resolve scope from `REPO_TAXONOMY.md`
-2. load only task-relevant doctrine files
-3. run deterministic checks and rules first
-4. use small-model JSON classification only when rules are insufficient
-5. emit structured result
-6. emit approval bundle if any write is proposed
+2. load local roadmap/tracker artifacts when the task is career or planning related
+3. load only task-relevant doctrine files
+4. run deterministic checks and rules first
+5. use small-model JSON classification only when rules are insufficient
+6. emit structured result
+7. emit approval bundle if any write is proposed
 
 This keeps cost low and prevents policy invention.
 
@@ -327,6 +445,7 @@ This keeps Mia compatible with the future `llm-platform` shared gateway without 
 - add labels
 - post templated comments
 - create draft issue or report artifacts
+- draft roadmap or tracker updates for human review
 
 ### Not allowed in v1
 
@@ -361,6 +480,106 @@ This keeps Mia compatible with the future `llm-platform` shared gateway without 
 
 These require CI, runtime, incident, survey, or manual-input sources not guaranteed to exist inside Mia.
 
+## Career Tracking Rules
+
+- the roadmap and tracker are the primary planning surface
+- repo or issue activity is supporting evidence, not authoritative proof of progress
+- completed progress should be confirmed explicitly by the human
+- heartbeat prompts may request updates, but must not assume completion
+- when priorities conflict, Mia should recommend narrowing scope rather than expanding it
+
+## Future Learning Loop Alignment
+
+The current interactive assistant should be compatible with the proposed
+`LEARNING_LOOP_MODEL` direction from `platform-docs#71`.
+
+That means:
+
+- roadmap and tracker artifacts should remain easy to inspect and diff
+- findings should be expressible as small structured proposals
+- low-risk outputs may eventually be auto-drafted
+- high-risk outputs should remain queued for review
+- transcript-derived insights should supplement, not replace, explicit human progress confirmation
+
+## Proposal Tiers
+
+Future learning-loop proposals should be split by target surface and risk, not
+just by convenience.
+
+### Tier 1: Low-Risk Auto-Draft Candidates
+
+Allowed as future auto-drafts, still reviewable:
+
+- Mia memory updates
+- draft issue creation in the appropriate repo
+- draft tracker or roadmap updates for human review
+- draft notes pointing to recurring manual steps or stale priorities
+
+Conditions:
+
+- the finding is backed by explicit evidence
+- no GitOps, CI, policy, or governance mutation is implied
+- the output is reversible and easy to inspect
+
+### Tier 2: Review-Queue Only
+
+Must always be queued for human review:
+
+- `gitops` changes
+- CI or workflow gate changes
+- policy or doctrine additions
+- lifecycle or contract-surface changes
+- any recommendation that mutates shared infrastructure behavior
+
+Conditions:
+
+- findings may still be normalized and summarized automatically
+- output should point to the owning repo and suggested issue surface
+- no direct mutation should happen from Mia v1 or the first learning-loop phase
+
+### Tier 3: Out Of Scope
+
+Not appropriate for Mia's early learning-loop phases:
+
+- direct cluster actions
+- unattended GitOps mutation
+- automatic pull request merge or closure
+- automatic progress completion based only on transcript or repo inference
+
+## Source Validity Rules
+
+Not every artifact is equally trustworthy as a learning-loop input.
+
+Primary valid sources:
+
+- interactive assistant session transcripts
+- approved manual notes
+- issue discussions
+- reviewable repository work artifacts
+
+Secondary supporting sources:
+
+- PR comments
+- local tracker history
+- linked runbooks and docs
+
+Weak sources that should not stand alone:
+
+- single unverified agent response
+- inferred intent from one commit
+- one-off exploratory shell output without corroboration
+
+## Owning Surface Rules
+
+Learning-loop outputs should land in the natural owning surface:
+
+- personal planning or reminder refinement: `mia`
+- doctrine, methodology, or governance gaps: `platform-docs`
+- runtime desired state or lifecycle gaps: `gitops`
+- workload-specific follow-up: owning workload repo issue
+
+Mia may prepare the proposal, but should not redefine ownership.
+
 ## Risk Controls
 
 - manual-trigger only
@@ -374,6 +593,9 @@ These require CI, runtime, incident, survey, or manual-input sources not guarant
 
 V1 succeeds when:
 
+- Mia can review the roadmap and identify active priorities, slipped items, and blockers.
+- Mia can support a weekly planning and review loop without inventing progress.
+- Mia has a clear extension path toward retrospective learning-loop proposals without claiming autonomous execution today.
 - Mia can triage a single issue or discussion into the documented friction flow.
 - Mia can compute a Formation measurement snapshot from governed repositories.
 - Mia can produce an audit evidence bundle with explicit authorities and findings.
@@ -385,11 +607,24 @@ V1 succeeds when:
 The first implementation slice should add:
 
 - assistant configuration surface
+- roadmap, progress tracker, and weekly review artifacts
 - schema definitions for the output contract
-- doctrine-to-task mapping
+- doctrine-to-task and roadmap-to-task mapping
 - one end-to-end issue triage path
+- one end-to-end roadmap review path
 - one end-to-end formation measurement path
 - one end-to-end audit evidence path
+
+## Phase 2 Direction
+
+After v1 proves useful interactively, the next logical phase is to align Mia
+with the proposed `LEARNING_LOOP_MODEL`:
+
+- ingest session findings from an approved source
+- detect repeat patterns and missed automation opportunities
+- generate `LearningLoopFinding` proposals
+- auto-draft only low-risk outputs
+- queue infrastructure, CI, policy, and governance changes for review
 
 ## Manual Human Steps
 

--- a/docs/weekly-review-template.md
+++ b/docs/weekly-review-template.md
@@ -1,0 +1,63 @@
+# Weekly Review Template
+
+## Purpose
+
+Use this template with Mia for a consistent weekly review.
+
+The goal is to surface drift early, reduce hidden blockers, and keep the next
+week narrow enough to execute.
+
+## Prompt Shape
+
+Suggested manual trigger:
+
+```text
+review week
+```
+
+## Review Questions
+
+1. What were the top priorities this week?
+2. What actually got completed?
+3. What slipped?
+4. What is blocked?
+5. Which goals still matter next week?
+6. Which goals should be dropped, deferred, or narrowed?
+7. What are the top three priorities for the next week?
+
+## Output Expectations
+
+Mia should produce:
+
+- a short summary
+- completed items
+- slipped items
+- blockers
+- recommended next actions
+- proposed tracker updates for review
+
+## Anti-Patterns
+
+- too many priorities
+- treating repo activity as automatic completion
+- carrying stale goals forward without re-justifying them
+- adding new work without removing old commitments
+
+## Example Review Outcome
+
+```text
+Summary:
+- Mia repositioning progressed.
+- OpenShift learning remains active but is no longer the main capability proving surface.
+
+Slipped:
+- live RabbitMQ runtime validation did not complete because cluster readiness remained unstable.
+
+Blockers:
+- Mia still lacks dedicated action identity and scoped credentials.
+
+Next actions:
+- finish Mia v1 planning artifacts
+- standardize weekly review cadence
+- decide when to add scoped write actions after identity work
+```


### PR DESCRIPTION
## Summary
- reposition Mia from a narrow OpenClaw gateway framing into a bounded platform and career assistant
- add canonical roadmap, progress tracker, and weekly review artifacts for interactive planning and reminders
- align Mia's future Phase 2 direction with the proposed learning-loop model in `zavestudios/platform-docs#71`
- define proposal tiers, evidence rules, and owning-surface boundaries for future learning-loop outputs

## Linked Work
- closes #28
- related prerequisite: #21
- related upstream model direction: zavestudios/platform-docs#71

## Testing
- reviewed the updated docs and config for internal consistency
- no runtime validation performed in this PR

## Notes
- V1 remains manual-trigger plus heartbeat-prompt only
- unattended polling, transcript ingestion, and high-risk write actions remain out of scope in this slice
