### PR TITLE
feat: enable OTEL export from Mia gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Mia - OpenClaw AI Gateway
 # Use the official OpenClaw runtime image and layer workload defaults.
-FROM ghcr.io/openclaw/openclaw:v2026.3.8@sha256:7b1294f6aa2eb05b2070cc614743f79212313fc294e5de221ada8a2969ea52f6
+FROM ghcr.io/openclaw/openclaw:2026.5.12@sha256:e2482a66682de6f540dcfd9921e410c23fd060dcd441382ff952247ee911a672
 ENV HOME=/home/node
 
 # Accept phone numbers as build arguments (default to empty arrays for local dev)

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN sed -e "s|\"{{WHATSAPP_ALLOW_FROM}}\"|${WHATSAPP_ALLOW_FROM}|g" \
 
 USER node
 
-# Install the official OTEL diagnostics plugin so the gateway can export traces,
-# metrics, and logs to the shared in-cluster Alloy receiver.
-RUN openclaw plugins install @openclaw/diagnostics-otel
+# Install the official WhatsApp plugin explicitly. In OpenClaw 2026.5.x the
+# WhatsApp dependency cone is no longer part of the lean core runtime image.
+RUN openclaw plugins install clawhub:@openclaw/whatsapp
 
 EXPOSE 18789

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,10 @@ RUN sed -e "s|\"{{WHATSAPP_ALLOW_FROM}}\"|${WHATSAPP_ALLOW_FROM}|g" \
     && chown node:node /home/node/.openclaw/openclaw.json \
     && rm /tmp/openclaw.json
 
-EXPOSE 18789
 USER node
+
+# Install the official OTEL diagnostics plugin so the gateway can export traces,
+# metrics, and logs to the shared in-cluster Alloy receiver.
+RUN openclaw plugins install clawhub:@openclaw/diagnostics-otel
+
+EXPOSE 18789

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ USER node
 
 # Install the official OTEL diagnostics plugin so the gateway can export traces,
 # metrics, and logs to the shared in-cluster Alloy receiver.
-RUN openclaw plugins install clawhub:@openclaw/diagnostics-otel
+RUN openclaw plugins install @openclaw/diagnostics-otel
 
 EXPOSE 18789

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -1,7 +1,14 @@
 {
   "gateway": {
+    "mode": "local",
     "port": 18789,
     "bind": "lan",
+    "controlUi": {
+      "allowedOrigins": [
+        "http://localhost:18789",
+        "http://127.0.0.1:18789"
+      ]
+    },
     "auth": {
       "rateLimit": {
         "maxAttempts": 10,
@@ -11,12 +18,22 @@
     }
   },
   "plugins": {
-    "allow": ["diagnostics-otel"],
+    "allow": ["anthropic", "diagnostics-otel", "ollama", "whatsapp"],
     "entries": {
+      "anthropic": {
+        "enabled": true
+      },
       "diagnostics-otel": {
         "enabled": true
+      },
+      "ollama": {
+        "enabled": true
+      },
+      "whatsapp": {
+        "enabled": true
       }
-    }
+    },
+    "bundledDiscovery": "allowlist"
   },
   "diagnostics": {
     "enabled": true,
@@ -60,6 +77,11 @@
       "allowFrom": "{{WHATSAPP_ALLOW_FROM}}",
       "groupPolicy": "allowlist",
       "groupAllowFrom": "{{WHATSAPP_GROUP_ALLOW_FROM}}"
+    }
+  },
+  "messages": {
+    "groupChat": {
+      "visibleReplies": "message_tool"
     }
   }
 }

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -10,6 +10,24 @@
       }
     }
   },
+  "plugins": {
+    "allow": ["diagnostics-otel"],
+    "entries": {
+      "diagnostics-otel": {
+        "enabled": true
+      }
+    }
+  },
+  "diagnostics": {
+    "enabled": true,
+    "otel": {
+      "enabled": true,
+      "protocol": "http/protobuf",
+      "traces": true,
+      "metrics": true,
+      "logs": true
+    }
+  },
   "agents": {
     "defaults": {
       "model": {


### PR DESCRIPTION
## Summary

Enable OpenTelemetry export from the Mia OpenClaw runtime.

## Changes

- install the official `@openclaw/diagnostics-otel` plugin in the runtime image
- enable OpenClaw diagnostics OTEL export in `config/openclaw.json`
- keep plugin installation under the `node` user so runtime ownership stays consistent

## Notes

This is the source-side half of the Mia tracing path.

The corresponding tenant deployment wiring lives in `zavestudios/gitops` and points OTLP/HTTP at the shared Alloy receiver.

A new image build and digest promotion will still be required before end-to-end tracing can be verified in-cluster.

## Related

- `zavestudios/mia#30`
- `zavestudios/gitops#190`