### PR TITLE
[codex] Align Mia observability contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Mia - OpenClaw AI Gateway
 # Use the official OpenClaw runtime image and layer workload defaults.
-FROM ghcr.io/openclaw/openclaw:2026.5.12@sha256:e2482a66682de6f540dcfd9921e410c23fd060dcd441382ff952247ee911a672
+FROM ghcr.io/openclaw/openclaw:2026.5.22@sha256:dcfd148777401d1bbdc63eab5c2f280bbfa912dfb1818566f9d66bb96ffb3f95
 ENV HOME=/home/node
 
 # Accept phone numbers as build arguments (default to empty arrays for local dev)

--- a/zave.yaml
+++ b/zave.yaml
@@ -15,7 +15,6 @@ spec:
     engine: postgres
 
   capabilities:
-    - name: metrics
     - name: tracing
 
   resources:


### PR DESCRIPTION
## Summary
- remove the `metrics` capability declaration from `mia`
- keep `tracing` as the currently materialized observability capability

## Why
`mia` was declaring both `metrics` and `tracing`, but the current governed materialization only proves the tracing path. The platform contract still defines `metrics` as a Prometheus-style scrape capability, and `mia` does not currently materialize that path.

This keeps the tenant contract aligned with live platform behavior instead of overstating capability completion.

## Impact
- makes `mia` truthful about the observability capabilities it currently consumes
- keeps metrics validation separate from tracing validation during Formation

## Validation
- reviewed `mia/zave.yaml`
- compared tenant contract state against current GitOps observability materialization
