### PR TITLE
Document Mia OTEL trace verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ USER node
 
 # Install the official WhatsApp plugin explicitly. In OpenClaw 2026.5.x the
 # WhatsApp dependency cone is no longer part of the lean core runtime image.
-RUN openclaw plugins install clawhub:@openclaw/whatsapp
+# Pin the plugin to the runtime family so clawhub/npm latest cannot drift past
+# the pinned OpenClaw plugin API exposed by the base image.
+RUN openclaw plugins install @openclaw/whatsapp@2026.5.22
 
 EXPOSE 18789

--- a/docs/interaction-smoke-test.md
+++ b/docs/interaction-smoke-test.md
@@ -8,6 +8,7 @@ Purpose: provide one repeatable operator check after deploys.
 - Validate dashboard access path.
 - Validate runtime stability signals.
 - For OTEL trace validation, use [otel-tracing-verification.md](otel-tracing-verification.md).
+- For OpenClaw runtime and plugin compatibility history, use [runtime-dependency-record.md](runtime-dependency-record.md).
 
 ## Procedure
 

--- a/docs/interaction-smoke-test.md
+++ b/docs/interaction-smoke-test.md
@@ -7,6 +7,7 @@ Purpose: provide one repeatable operator check after deploys.
 - Validate gateway health.
 - Validate dashboard access path.
 - Validate runtime stability signals.
+- For OTEL trace validation, use [otel-tracing-verification.md](otel-tracing-verification.md).
 
 ## Procedure
 

--- a/docs/otel-tracing-verification.md
+++ b/docs/otel-tracing-verification.md
@@ -1,0 +1,103 @@
+# OTEL Tracing Verification
+
+Purpose: verify that Mia emits OpenTelemetry signals through the shared Alloy receiver and that traces are visible in Tempo/Grafana.
+
+This is the focused closure path for `zavestudios/mia#30`.
+
+## Scope
+
+- Confirm the running deployment has the expected OTEL environment.
+- Confirm the OpenClaw runtime config enables diagnostics OTEL export.
+- Generate one real Mia request.
+- Confirm Tempo/Grafana shows a trace for `mia-gateway`.
+
+## Procedure
+
+1. Confirm deployment wiring.
+
+**Requires cluster access:**
+
+```bash
+kubectl -n mia get deploy mia -o jsonpath='{range .spec.template.spec.containers[?(@.name=="mia")].env[*]}{.name}={.value}{"\n"}{end}' \
+  | rg 'OTEL_EXPORTER_OTLP_ENDPOINT|OTEL_EXPORTER_OTLP_PROTOCOL|OTEL_SERVICE_NAME'
+
+kubectl -n alloy get svc alloy-receiver -o wide
+kubectl -n alloy logs deploy/alloy-receiver --since=15m
+```
+
+Pass signals:
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy-receiver.alloy.svc.cluster.local:4318`
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
+- `OTEL_SERVICE_NAME=mia-gateway`
+- `alloy-receiver` Service exists in namespace `alloy`
+- receiver logs do not show repeated OTLP receive or Tempo export failures
+
+2. Confirm OpenClaw diagnostics config.
+
+**Requires cluster access:**
+
+```bash
+kubectl -n mia exec deploy/mia -- node -e '
+const fs = require("fs");
+const cfg = JSON.parse(fs.readFileSync("/home/node/.openclaw/openclaw.json", "utf8"));
+console.log(JSON.stringify({
+  pluginAllowed: cfg.plugins?.allow?.includes("diagnostics-otel"),
+  pluginEnabled: cfg.plugins?.entries?.["diagnostics-otel"]?.enabled,
+  diagnostics: cfg.diagnostics
+}, null, 2));
+'
+```
+
+Pass signals:
+- `pluginAllowed` is `true`
+- `pluginEnabled` is `true`
+- `diagnostics.enabled` is `true`
+- `diagnostics.otel.enabled` is `true`
+- `diagnostics.otel.traces` is `true`
+
+3. Generate a real request through Mia.
+
+Use the normal operator access path from [interaction-smoke-test.md](interaction-smoke-test.md), then send a request that produces a successful assistant response.
+
+**Requires cluster access:**
+
+```bash
+kubectl -n mia exec deploy/mia -- openclaw gateway health --json
+kubectl -n mia exec deploy/mia -- openclaw status --json
+```
+
+Pass signals:
+- gateway health returns `"ok": true`
+- the request completes successfully from the operator UI or configured channel
+
+4. Verify trace visibility.
+
+Open Grafana and use the Tempo data source to search for:
+
+- service name: `mia-gateway`
+- time range: last 15 minutes
+- operation/span names associated with the request generated in step 3
+
+Pass signals:
+- at least one trace is visible for `mia-gateway`
+- trace timestamp matches the request window
+- trace details show Mia/OpenClaw request handling rather than only collector internals
+
+## Fail Criteria
+
+- OTEL environment variables are absent from the running `mia` container.
+- `alloy-receiver` Service is absent or not accepting OTLP/HTTP.
+- OpenClaw effective config does not enable diagnostics OTEL.
+- No `mia-gateway` traces appear in Tempo after a successful real request.
+- Alloy logs show repeated export failures to Tempo.
+
+## Evidence To Capture
+
+Record these in the issue comment when closing `zavestudios/mia#30`:
+
+- deployed Mia image digest
+- timestamp and timezone for the generated request
+- `OTEL_SERVICE_NAME` observed in the running deployment
+- Grafana/Tempo query used
+- whether traces, metrics, and logs appeared as expected
+- any remaining gap between Mia's declared tracing capability and the operator workflow

--- a/docs/otel-tracing-verification.md
+++ b/docs/otel-tracing-verification.md
@@ -1,6 +1,6 @@
 # OTEL Tracing Verification
 
-Purpose: verify that Mia emits OpenTelemetry signals through the shared Alloy receiver and that traces are visible in Tempo/Grafana.
+Purpose: verify that Mia emits OpenTelemetry traces through the shared Alloy receiver and that those traces are visible in Tempo/Grafana.
 
 This is the focused closure path for `zavestudios/mia#30`.
 
@@ -99,5 +99,5 @@ Record these in the issue comment when closing `zavestudios/mia#30`:
 - timestamp and timezone for the generated request
 - `OTEL_SERVICE_NAME` observed in the running deployment
 - Grafana/Tempo query used
-- whether traces, metrics, and logs appeared as expected
+- whether traces appeared as expected
 - any remaining gap between Mia's declared tracing capability and the operator workflow

--- a/docs/runtime-dependency-record.md
+++ b/docs/runtime-dependency-record.md
@@ -1,0 +1,69 @@
+# Runtime Dependency Record
+
+Purpose: keep Mia's OpenClaw runtime and plugin compatibility history explicit so image build failures do not have to be reconstructed from PR memory.
+
+## Current Source Of Truth
+
+- Runtime image: `Dockerfile`
+- OpenClaw config: `config/openclaw.json`
+- Deployed image digest: `zavestudios/gitops/tenants/mia/deployment.yaml`
+- Observability capability declaration: `zave.yaml`
+
+## Current Runtime Baseline
+
+As of PR #33, the Dockerfile pins:
+
+```dockerfile
+FROM ghcr.io/openclaw/openclaw:2026.5.22@sha256:dcfd148777401d1bbdc63eab5c2f280bbfa912dfb1818566f9d66bb96ffb3f95
+```
+
+The image build installs the external WhatsApp plugin with:
+
+```dockerfile
+RUN openclaw plugins install clawhub:@openclaw/whatsapp
+```
+
+That plugin reference is not version-pinned. A future `clawhub` release can become incompatible with the pinned OpenClaw runtime even when the Dockerfile has not changed.
+
+## Compatibility History
+
+| Date | Commit | Runtime / Plugin Change | Record |
+| --- | --- | --- | --- |
+| 2026-03-11 | `8354fb2` | Pinned OpenClaw `v2026.3.8` by digest | Early stable runtime pin |
+| 2026-05-17 | `54f459c`, `260bc46` | Added `@openclaw/diagnostics-otel` install attempt | Initial OTEL source-side plugin work |
+| 2026-05-17 | `73cd74b` | Upgraded OpenClaw to `2026.5.12` by digest | Compatibility upgrade for newer OpenClaw behavior |
+| 2026-05-17 | `8246300` | Replaced diagnostics plugin install with `clawhub:@openclaw/whatsapp` | OpenClaw `2026.5.x` no longer carried WhatsApp in the lean runtime image |
+| 2026-05-26 | `9ce5892` | Bumped OpenClaw to `2026.5.22` by digest | Follow-up runtime bump for WhatsApp plugin compatibility |
+
+## Important Correction
+
+PR #31 says the runtime image installs `@openclaw/diagnostics-otel`. That was true for the first commits in the PR, but the final merged Dockerfile does not install that plugin. The final merged state enables diagnostics OTEL in `config/openclaw.json` and installs the external WhatsApp plugin.
+
+Mia's current governed observability capability is `tracing`, not `metrics`. The remaining proof for `zavestudios/mia#30` is runtime evidence that a real Mia request appears in Tempo as `mia-gateway`.
+
+## Known Failure Class
+
+Failure signature:
+
+```text
+Plugin "@openclaw/whatsapp" requires plugin API >=2026.6.10,
+but this OpenClaw runtime exposes 2026.5.22.
+```
+
+Meaning:
+
+- The Dockerfile still pins OpenClaw `2026.5.22`.
+- The unpinned WhatsApp plugin resolver selected a newer plugin requiring OpenClaw plugin API `>=2026.6.10`.
+- This is a mutable dependency failure, not evidence that the docs-only PR changed the image.
+
+Preferred fixes, in order:
+
+1. Pin `@openclaw/whatsapp` to a version compatible with OpenClaw `2026.5.22`, if the plugin registry supports immutable version selection.
+2. Upgrade the OpenClaw base image to a runtime exposing plugin API `>=2026.6.10`, then rebuild and promote the resulting image digest through GitOps.
+3. If neither option is immediately available, keep the failure recorded here and avoid treating unrelated docs PRs as image validation evidence.
+
+## Operational Rule
+
+When changing `Dockerfile` or `config/openclaw.json`, record the runtime version, plugin references, and expected plugin API compatibility in this file.
+
+When only docs change, do not infer runtime compatibility from CI unless the container workflow intentionally ran for an image-affecting path.

--- a/docs/runtime-dependency-record.md
+++ b/docs/runtime-dependency-record.md
@@ -20,10 +20,10 @@ FROM ghcr.io/openclaw/openclaw:2026.5.22@sha256:dcfd148777401d1bbdc63eab5c2f280b
 The image build installs the external WhatsApp plugin with:
 
 ```dockerfile
-RUN openclaw plugins install clawhub:@openclaw/whatsapp
+RUN openclaw plugins install @openclaw/whatsapp@2026.5.22
 ```
 
-That plugin reference is not version-pinned. A future `clawhub` release can become incompatible with the pinned OpenClaw runtime even when the Dockerfile has not changed.
+That plugin reference is version-pinned to match the pinned OpenClaw runtime family.
 
 ## Compatibility History
 
@@ -34,6 +34,7 @@ That plugin reference is not version-pinned. A future `clawhub` release can beco
 | 2026-05-17 | `73cd74b` | Upgraded OpenClaw to `2026.5.12` by digest | Compatibility upgrade for newer OpenClaw behavior |
 | 2026-05-17 | `8246300` | Replaced diagnostics plugin install with `clawhub:@openclaw/whatsapp` | OpenClaw `2026.5.x` no longer carried WhatsApp in the lean runtime image |
 | 2026-05-26 | `9ce5892` | Bumped OpenClaw to `2026.5.22` by digest | Follow-up runtime bump for WhatsApp plugin compatibility |
+| 2026-06-27 | PR #33 | Pinned WhatsApp plugin to `@openclaw/whatsapp@2026.5.22` | Prevents mutable `clawhub` latest from selecting a plugin requiring a newer OpenClaw plugin API |
 
 ## Important Correction
 
@@ -56,11 +57,15 @@ Meaning:
 - The unpinned WhatsApp plugin resolver selected a newer plugin requiring OpenClaw plugin API `>=2026.6.10`.
 - This is a mutable dependency failure, not evidence that the docs-only PR changed the image.
 
-Preferred fixes, in order:
+Applied fix:
 
-1. Pin `@openclaw/whatsapp` to a version compatible with OpenClaw `2026.5.22`, if the plugin registry supports immutable version selection.
-2. Upgrade the OpenClaw base image to a runtime exposing plugin API `>=2026.6.10`, then rebuild and promote the resulting image digest through GitOps.
-3. If neither option is immediately available, keep the failure recorded here and avoid treating unrelated docs PRs as image validation evidence.
+- Pin the plugin install to `@openclaw/whatsapp@2026.5.22`, which declares `openclaw >=2026.5.22` and `pluginApi >=2026.5.22`.
+
+Future fixes, if a newer plugin is required:
+
+1. Upgrade the OpenClaw base image to a runtime exposing the required plugin API.
+2. Pin the WhatsApp plugin to the same compatible version family.
+3. Rebuild and promote the resulting image digest through GitOps.
 
 ## Operational Rule
 


### PR DESCRIPTION
## Summary

- Add a focused OTEL tracing verification runbook for Mia.
- Link the OTEL runbook from the existing interaction smoke test.
- Add a runtime dependency record for OpenClaw and plugin compatibility history.
- Pin the WhatsApp plugin install to `@openclaw/whatsapp@2026.5.22` so mutable `clawhub` latest cannot drift past the pinned OpenClaw runtime API.

## Related

- Supports zavestudios/mia#30

## Testing

- git diff --check
- docker build --build-arg WHATSAPP_ALLOW_FROM='[]' --build-arg WHATSAPP_GROUP_ALLOW_FROM='[]' -t mia:plugin-pin-test .

## Breaking Changes

None.